### PR TITLE
Change config api and add getClient and validateToken methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,10 @@ $ npm i --save hydra-js
 var Hydra = require('hydra-js')
 
 const config = {
- client: {
-   id: process.env.HYDRA_CLIENT_ID, // id of the client you want to use, defaults to this env var
-   secret: process.env.HYDRA_CLIENT_SECRET, // secret of the client you want to use, defaults to this env var
- },
- auth: {
-   tokenHost: process.env.HYDRA_URL, // hydra url, defaults to this env var
- }
+ clientId:     process.env.HYDRA_CLIENT_ID,     // id of the client you want to use, defaults to this env var
+ clientSecret: process.env.HYDRA_CLIENT_SECRET, // secret of the client you want to use, defaults to this env var
+ endpoint:     process.env.HYDRA_URL,           // hydra url, defaults to this env var
+ scope:        'hydra.keys.get'                 // scope of the authorization, defaults to 'hydra.keys.get'
 }
 
 const hydra = new Hydra(config)

--- a/README.md
+++ b/README.md
@@ -36,10 +36,16 @@ $ npm i --save hydra-js
 var Hydra = require('hydra-js')
 
 const config = {
- clientId:     process.env.HYDRA_CLIENT_ID,     // id of the client you want to use, defaults to this env var
- clientSecret: process.env.HYDRA_CLIENT_SECRET, // secret of the client you want to use, defaults to this env var
- endpoint:     process.env.HYDRA_URL,           // hydra url, defaults to this env var
- scope:        'hydra.keys.get'                 // scope of the authorization, defaults to 'hydra.keys.get'
+ client: {
+   id: process.env.HYDRA_CLIENT_ID, // id of the client you want to use, defaults to this env var
+   secret: process.env.HYDRA_CLIENT_SECRET, // secret of the client you want to use, defaults to this env var
+ },
+ auth: {
+   tokenHost: process.env.HYDRA_URL, // hydra url, defaults to this env var
+   authorizePath: '/oauth2/auth', // hydra authorization endpoint, defaults to '/oauth2/auth'
+   tokenPath: '/oauth2/token', // hydra token endpoint, defaults to '/oauth2/token'
+ },
+ scope: 'hydra.keys.get' // scope of the authorization, defaults to 'hydra.keys.get'
 }
 
 const hydra = new Hydra(config)

--- a/hydra.js
+++ b/hydra.js
@@ -7,19 +7,26 @@ const jwkToPem = require('jwk-to-pem')
 require('superagent-auth-bearer')(request)
 
 class Hydra {
-  constructor(config) {
-    this.config = Object.assign({
+  constructor(config = {}) {
+    let {
+      clientId = process.env.HYDRA_CLIENT_ID,
+      clientSecret = process.env.HYDRA_CLIENT_SECRET,
+      endpoint = process.env.HYDRA_URL,
+      scope = 'hydra.keys.get'} = config
+
+    this.config = {
       client: {
-        id: process.env.HYDRA_CLIENT_ID,
-        secret: process.env.HYDRA_CLIENT_SECRET,
+        id: clientId,
+        secret: clientSecret
       },
       auth: {
-        tokenHost: process.env.HYDRA_URL,
+        tokenHost: endpoint,
         authorizePath: '/oauth2/auth',
         tokenPath: '/oauth2/token'
-      }
-    }, config)
-    this.endpoint = this.config.auth.tokenHost
+      },
+    }
+    this.scope = scope
+    this.endpoint = endpoint
     this.token = null
   }
 
@@ -30,7 +37,7 @@ class Hydra {
       }
 
       this.oauth2 = OAuth2.create(this.config)
-      this.oauth2.clientCredentials.getToken({ scope: 'hydra.keys.get' }, (error, result) => {
+      this.oauth2.clientCredentials.getToken({ scope: this.scope }, (error, result) => {
         if (error) {
           return reject({ message: 'Could not retrieve access token: ' + error.message })
         }

--- a/hydra.js
+++ b/hydra.js
@@ -9,10 +9,16 @@ require('superagent-auth-bearer')(request)
 class Hydra {
   constructor(config = {}) {
     let {
-      clientId = process.env.HYDRA_CLIENT_ID,
-      clientSecret = process.env.HYDRA_CLIENT_SECRET,
-      endpoint = process.env.HYDRA_URL,
-      scope = 'hydra.keys.get'} = config
+      client: {
+        id: clientId = process.env.HYDRA_CLIENT_ID,
+        secret: clientSecret = process.env.HYDRA_CLIENT_SECRET
+      } = {},
+      auth: {
+        tokenHost: endpoint = process.env.HYDRA_URL,
+        authorizePath: authorizePath = '/oauth2/auth',
+        tokenPath: tokenPath = '/oauth2/token'
+      } = {},
+      scope: scope = 'hydra.keys.get'} = config
 
     this.config = {
       client: {
@@ -21,8 +27,8 @@ class Hydra {
       },
       auth: {
         tokenHost: endpoint,
-        authorizePath: '/oauth2/auth',
-        tokenPath: '/oauth2/token'
+        authorizePath: authorizePath,
+        tokenPath: tokenPath
       },
     }
     this.scope = scope
@@ -120,10 +126,8 @@ class Hydra {
           }
           resolve(res.body)
         })
-      }).catch((e) => {
-        console.error(e)
       })
-    });
+    })
   }
 }
 

--- a/hydra.js
+++ b/hydra.js
@@ -109,6 +109,22 @@ class Hydra {
       })
     })
   }
+
+  validateToken(token) {
+    return new Promise((resolve, reject) => {
+      return this.authenticate().then(() => {
+        request.post(`${this.endpoint}/oauth2/introspect`).send(`token=${token}`).authBearer(this.token.token.access_token).end((err, res) => {
+          if (err || !res.ok) {
+            reject({ error: 'Intospection failed: ' + err && err.message })
+            return
+          }
+          resolve(res.body)
+        })
+      }).catch((e) => {
+        console.error(e)
+      })
+    });
+  }
 }
 
 module.exports = Hydra

--- a/hydra.js
+++ b/hydra.js
@@ -95,6 +95,20 @@ class Hydra {
       })
     })
   }
+
+  getClient(id) {
+    return new Promise((resolve, reject) => {
+      return this.authenticate().then(() => {
+        request.get(`${this.endpoint}/clients/${id}`).authBearer(this.token.token.access_token).end((err, res) => {
+          if (err || !res.ok) {
+            reject({ error: 'Could not retrieve client: ' + err && err.message })
+            return
+          }
+          resolve(res.body)
+        })
+      })
+    })
+  }
 }
 
 module.exports = Hydra

--- a/hydra.test.js
+++ b/hydra.test.js
@@ -57,6 +57,18 @@ describe('services', () => {
       })
     })
 
+    test('getClient() should fetch a client from the backend', () => {
+      const client = {
+        dummy: true
+      }
+      nock('http://foo.localhost').get('/clients/foo').reply(200, client)
+
+      const h = new Hydra(Object.assign({scope: 'hydra.clients'}, config))
+      return h.getClient('foo').then((got) => {
+        expect(got).toEqual(client)
+      })
+    })
+
     test('consent challenge verification and consent response signing should work when a valid key is provided', () => new Promise((resolve, reject) => {
       const keys = {
         "keys": [

--- a/hydra.test.js
+++ b/hydra.test.js
@@ -6,7 +6,7 @@ var jwkToPem = require('jwk-to-pem')
 
 describe('services', () => {
   describe('Hydra', () => {
-    const config = {
+    const simpleOauth2config = {
       client: {
         id: 'client',
         secret: 'secret'
@@ -17,11 +17,16 @@ describe('services', () => {
         tokenPath: '/oauth2/token'
       }
     }
+    const config = {
+      clientId: simpleOauth2config.client.id,
+      clientSecret: simpleOauth2config.client.secret,
+      endpoint: simpleOauth2config.auth.tokenHost
+    }
 
     test('constructor should override default values', () => {
       const h = new Hydra(config)
-      expect(h.config).toEqual(config)
-      expect(h.endpoint).toEqual(config.auth.tokenHost)
+      expect(h.config).toEqual(simpleOauth2config)
+      expect(h.endpoint).toEqual(config.endpoint)
     })
 
     // set up oauth2 endpoint

--- a/hydra.test.js
+++ b/hydra.test.js
@@ -69,6 +69,17 @@ describe('services', () => {
       })
     })
 
+    test('validateToken() token introspection', () => {
+      nock('http://foo.localhost').post('/oauth2/introspect', 'token=foo').reply(200, {
+        active: true
+      })
+
+      const h = new Hydra(Object.assign({scope: 'hydra.clients'}, config))
+      return h.validateToken('foo').then((got) => {
+        expect(got.active).toEqual(true)
+      })
+    })
+
     test('consent challenge verification and consent response signing should work when a valid key is provided', () => new Promise((resolve, reject) => {
       const keys = {
         "keys": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra-js",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "A client library for Hydra, an OAuth2 and OpenID Connect Provider",
   "main": "hydra.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra-js",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "description": "A client library for Hydra, an OAuth2 and OpenID Connect Provider",
   "main": "hydra.js",
   "scripts": {


### PR DESCRIPTION
I had some problems with the way the constructor initialised the simple-oauth2 client (when creating a hydra clients with a configuration object the `auth.authorizePath` and `auth.tokenPath`, would default to the simple-oauth2 endpoints).

I think this way is cleaner, but I'm not sure if it breaks stuff (e.g. in the example consent app)?

Also I added a `getClient` and a `validateToken` method.