### PR TITLE
Unhandled promise rejections & friends :)

### DIFF
--- a/hydra.js
+++ b/hydra.js
@@ -107,7 +107,7 @@ class Hydra {
       return this.authenticate().then(() => {
         request.get(`${this.endpoint}/clients/${id}`).authBearer(this.token.token.access_token).end((err, res) => {
           if (err || !res.ok) {
-            reject({ error: 'Could not retrieve client: ' + err && err.message })
+            reject({ error: 'Could not retrieve client: ' + error })
             return
           }
           resolve(res.body)
@@ -121,7 +121,7 @@ class Hydra {
       return this.authenticate().then(() => {
         request.post(`${this.endpoint}/oauth2/introspect`).send(`token=${token}`).authBearer(this.token.token.access_token).end((err, res) => {
           if (err || !res.ok) {
-            reject({ error: 'Intospection failed: ' + err && err.message })
+            reject({ error: 'Intospection failed: ' + error })
             return
           }
           resolve(res.body)

--- a/hydra.js
+++ b/hydra.js
@@ -59,7 +59,7 @@ class Hydra {
       return this.authenticate().then(() => {
         request.get(`${this.endpoint}/keys/${set}/${kid}`).authBearer(this.token.token.access_token).end((err, res) => {
           if (err || !res.ok) {
-            reject({ error: 'Could not retrieve validation key: ' + err.message })
+            reject({ error: 'Could not retrieve validation key: ' + error })
             return
           }
           resolve(res.body.keys[0])

--- a/hydra.js
+++ b/hydra.js
@@ -59,7 +59,7 @@ class Hydra {
       return this.authenticate().then(() => {
         request.get(`${this.endpoint}/keys/${set}/${kid}`).authBearer(this.token.token.access_token).end((err, res) => {
           if (err || !res.ok) {
-            reject({ error: 'Could not retrieve validation key: ' + error })
+            reject({ error: 'Could not retrieve validation key: ' + err })
             return
           }
           resolve(res.body.keys[0])
@@ -107,7 +107,7 @@ class Hydra {
       return this.authenticate().then(() => {
         request.get(`${this.endpoint}/clients/${id}`).authBearer(this.token.token.access_token).end((err, res) => {
           if (err || !res.ok) {
-            reject({ error: 'Could not retrieve client: ' + error })
+            reject({ error: 'Could not retrieve client: ' + err })
             return
           }
           resolve(res.body)
@@ -121,7 +121,7 @@ class Hydra {
       return this.authenticate().then(() => {
         request.post(`${this.endpoint}/oauth2/introspect`).send(`token=${token}`).authBearer(this.token.token.access_token).end((err, res) => {
           if (err || !res.ok) {
-            reject({ error: 'Intospection failed: ' + error })
+            reject({ error: 'Intospection failed: ' + err })
             return
           }
           resolve(res.body)

--- a/hydra.js
+++ b/hydra.js
@@ -64,7 +64,7 @@ class Hydra {
           }
           resolve(res.body.keys[0])
         })
-      })
+      }, reject)
     })
   }
 
@@ -78,7 +78,7 @@ class Hydra {
           }
            resolve({ challenge: decoded })
         })
-      })
+      }, reject)
     })
   }
 
@@ -97,8 +97,8 @@ class Hydra {
             }
             resolve({ consent: token })
           })
-        })
-      })
+        }, reject)
+      }, reject)
     })
   }
 
@@ -112,7 +112,7 @@ class Hydra {
           }
           resolve(res.body)
         })
-      })
+      }, reject)
     })
   }
 
@@ -126,7 +126,7 @@ class Hydra {
           }
           resolve(res.body)
         })
-      })
+      }, reject)
     })
   }
 }

--- a/hydra.test.js
+++ b/hydra.test.js
@@ -35,6 +35,32 @@ describe('services', () => {
       scope: 'foo'
     }
 
+    const badHydra = new Hydra({
+      auth: { tokenHost: undefined },
+      client: { id: undefined, secret: undefined },
+      scope: undefined
+    });
+
+    test('simple-oauth2 errors should cause validateToken to reject()', () => {
+      return expect(badHydra.validateToken('foo')).rejects.toBeDefined()
+    })
+
+    test('simple-oauth2 errors should cause getClient to reject()', () => {
+      return expect(badHydra.getClient('foo')).rejects.toBeDefined()
+    })
+
+    test('simple-oauth2 errors should cause getKey to reject()', () => {
+      return expect(badHydra.getKey('foo', 'bar')).rejects.toBeDefined()
+    })
+
+    test('simple-oauth2 errors should cause verifyConsentChallenge to reject()', () => {
+      return expect(badHydra.verifyConsentChallenge('foo')).rejects.toBeDefined()
+    })
+
+    test('simple-oauth2 errors should cause generateConsentResponse to reject()', () => {
+      return expect(badHydra.generateConsentResponse('foo', 'bar', 'baz')).rejects.toBeDefined()
+    })
+
     test('constructor should override default values', () => {
       const h = new Hydra(config)
       expect(h.config).toEqual({client: config.client, auth: config.auth})

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "eslint": "^3.8.1",
     "eslint-config-ory-am": "^3.0.0",
-    "jest": "^16.0.2",
+    "jest": "^20.0.4",
     "jwt-decode": "^2.1.0",
     "nock": "^8.1.0"
   },


### PR DESCRIPTION
Just a couple of minor edits.

- `err || !res.ok` continues to dereference on `err`, even though it might be undefined (when `res.ok` is falsey). Also, string concatenation on an Error will trigger its `toString()` method, so the result when doing "dumb" concatenation is the same.
- `+` operand takes higher precedence than `&&`, so two error message string concatenations would return just the error object's message, without the intended prefix. I opted to continue the style from your own methods, discarding the truthy check on `err` and just concatenating it.
- The most important one is that some promise rejections weren't handled since promises are wrapped in promises rather than chaining, and so e.g. a thrown Error in `authenticate` (like when configuration options are missing or erroneous) would cause methods to never return, and a node log warning about the unhandled promise rejection.

Cheers! :)